### PR TITLE
Bump redis-rb dependency to >= 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.4.0
+- Bump redis-rb dependency to >= 4.2.0
+
 ## 1.3.2
 - Fixing bug where cached content was not read
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,26 @@
 PATH
   remote: .
   specs:
-    stockpile_cache (1.3.2)
+    stockpile_cache (1.4.0)
       connection_pool
       oj
       rake
-      redis
+      redis (>= 4.2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    connection_pool (2.2.2)
+    connection_pool (2.2.5)
     diff-lcs (1.3)
     jaro_winkler (1.5.3)
-    oj (3.10.6)
+    oj (3.13.9)
     parallel (1.17.0)
     parser (2.6.4.1)
       ast (~> 2.4.0)
     rainbow (3.0.0)
-    rake (13.0.1)
-    redis (4.1.4)
+    rake (13.0.6)
+    redis (4.4.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)

--- a/lib/stockpile/cache.rb
+++ b/lib/stockpile/cache.rb
@@ -35,7 +35,7 @@ module Stockpile
     end
 
     def get_deferred(db: :default, key:, compress: false)
-      sleep(Stockpile::SLUMBER_COOLDOWN) until Stockpile.redis(db: db) { |r| r.exists(key) }
+      sleep(Stockpile::SLUMBER_COOLDOWN) until Stockpile.redis(db: db) { |r| r.exists?(key) }
 
       get(db: db, key: key, compress: compress)
     end

--- a/lib/stockpile/constants.rb
+++ b/lib/stockpile/constants.rb
@@ -23,5 +23,5 @@ module Stockpile
   DEFAULT_TTL = 60 * 5
   LOCK_PREFIX = 'stockpile_lock::'
   SLUMBER_COOLDOWN = 0.05
-  VERSION = '1.3.2'
+  VERSION = '1.4.0'
 end

--- a/stockpile-cache.gemspec
+++ b/stockpile-cache.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'connection_pool'
   spec.add_dependency 'oj'
   spec.add_dependency 'rake'
-  spec.add_dependency 'redis'
+  spec.add_dependency 'redis', '>= 4.2.0'
 end


### PR DESCRIPTION
redis-rb 4.2.0 adds a new `exists?` method and deprecates the existing `exists`: https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#420