### PR TITLE
Add ability to renew cache key TTLs.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stockpile_cache (1.4.0)
+    stockpile_cache (1.5.0)
       connection_pool
       oj
       rake

--- a/lib/stockpile.rb
+++ b/lib/stockpile.rb
@@ -36,6 +36,7 @@ require 'stockpile/failed_lock_execution'
 require 'stockpile/cache'
 require 'stockpile/cached_value_reader'
 require 'stockpile/cached_value_expirer'
+require 'stockpile/cached_value_renewer'
 
 require 'stockpile/executor'
 
@@ -120,6 +121,25 @@ module Stockpile
       ttl: ttl,
       &block
     )
+  end
+
+  # Attempt to reset the TTL for a value cached under the given key.
+  #
+  # @param key [String] Key to renew cache TTL on
+  # @param db [Symbol] (optional) Which Redis database to cache data in.
+  #   Defaults to `:default`
+  # @param ttl [Integer] (optional) Time in seconds to expire cache after.
+  #   Defaults to Stockpile::DEFAULT_TTL
+  #
+  # @yield [block] A block of code to be executed in case of cache miss
+  #
+  # @example Renew cache operation
+  #   Stockpile.renew_cache(key: 'meaning_of_life', ttl: 42)
+  #
+  # @return [true] if the key existed (and was successfully renewed)
+  # @return [false] if the key did not exist
+  def renew_cache(key:, db: :default, ttl: Stockpile::DEFAULT_TTL)
+    Stockpile::CachedValueRenewer.renew(key: key, db: db, ttl: ttl)
   end
 
   # API to communicate with Redis database backing cache up.

--- a/lib/stockpile.rb
+++ b/lib/stockpile.rb
@@ -138,8 +138,8 @@ module Stockpile
   #
   # @return [true] if the key existed (and was successfully renewed)
   # @return [false] if the key did not exist
-  def renew_cache(key:, db: :default, ttl: Stockpile::DEFAULT_TTL)
-    Stockpile::CachedValueRenewer.renew(key: key, db: db, ttl: ttl)
+  def renew_cached(key:, db: :default, ttl: Stockpile::DEFAULT_TTL)
+    Stockpile::CachedValueRenewer.renew_cached(key: key, db: db, ttl: ttl)
   end
 
   # API to communicate with Redis database backing cache up.

--- a/lib/stockpile/cached_value_renewer.rb
+++ b/lib/stockpile/cached_value_renewer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Copyright 2019 ConvertKit, LLC
+# Copyright 2022 ConvertKit, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,13 +15,14 @@
 # limitations under the License.
 
 module Stockpile
-  DEFAULT_CONNECTION_POOL = 100
-  DEFAULT_CONNECTION_TIMEOUT = 3
-  DEFAULT_LOCK_EXPIRATION = 10
-  DEFAULT_REDIS_URL = 'redis://localhost:6379/1'
-  DEFAULT_SLUMBER = 2
-  DEFAULT_TTL = 60 * 5
-  LOCK_PREFIX = 'stockpile_lock::'
-  SLUMBER_COOLDOWN = 0.05
-  VERSION = '1.5.0'
+  # == Stockpile::CachedValueRenewer
+  #
+  # Service class to wrap renewing TTL of cached values
+  module CachedValueRenewer
+    module_function
+
+    def renew_cached(key:, db: :default, ttl: Stockpile::DEFAULT_TTL)
+      Stockpile.redis(db: db) { |r| r.expire(key, ttl) }
+    end
+  end
 end

--- a/spec/stockpile/cached_value_renewer_spec.rb
+++ b/spec/stockpile/cached_value_renewer_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Copyright 2022 ConvertKit, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+RSpec.describe Stockpile::CachedValueRenewer do
+  after(:each) do
+    Stockpile.redis { |r| r.expire('foo', 0) }
+  end
+
+  describe '#renew_cached' do
+    it 'expires cached values and returns true' do
+      Stockpile.redis { |r| r.set('foo', 1, ex: 10) }
+
+      expect(Stockpile.redis { |r| r.get('foo') }).to eq('1')
+      expect(Stockpile.redis { |r| r.ttl('foo') }).to be <= 10
+
+      result = Stockpile::CachedValueRenewer.renew_cached(key: 'foo', ttl: 100)
+
+      expect(result).to eq(true)
+      ttl = Stockpile.redis { |r| r.ttl('foo') }
+      # It's possible that we've paused for ... some amount of time since
+      # setting the TTL, so it might not literally be `100` when we run specs,
+      # but should be close.
+      expect(ttl).to be > 10
+      expect([100, 99, 98]).to include(ttl)
+    end
+
+    it 'returns false if value is not present in cache' do
+      expect(Stockpile.redis { |r| r.get('foo') }).to eq(nil)
+
+      result = Stockpile::CachedValueRenewer.renew_cached(key: 'foo', ttl: 100)
+
+      expect(result).to eq(false)
+    end
+  end
+end

--- a/spec/stockpile_spec.rb
+++ b/spec/stockpile_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe Stockpile do
     end
   end
 
+  describe '#renew_cached' do
+    it 'relays call to CachedValueRenewer' do
+      allow(Stockpile::CachedValueRenewer).to receive(:renew_cached)
+      expected_params = { db: :default, key: 'foo', ttl: 1 }
+      Stockpile.renew_cached(key: 'foo', ttl: 1)
+
+      expect(Stockpile::CachedValueRenewer).to have_received(:renew_cached).with(expected_params)
+    end
+  end
+
   describe '#redis' do
     it 'yields control' do
       expect { |b| Stockpile.redis(&b) }.to yield_control


### PR DESCRIPTION
We've identified a situation where we could benefit from being able to renew the timeout on a key without actually republishing the data.

Add a wrapper around the `expire` command to handle that, under a new `renew_cache` method.