### PR TITLE
Add ability to mirror database writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,48 @@ Using `configuration_file` setting will make Stockpile ignore all other
 Redis connection related settings and it will read configuration from `.yml`
 file instead.
 
+## Mirroring a Database
+Stockpile optionally supports mirroring database writes across two databases.
+To use mirroring you will have to use configuration file set by
+`STOCKPILE_CONFIGURATION_FILE`.
+
+To enable mirroring you have to do two things. First you have to set
+`configuration_file` setting to point at `.yml` containing your configuration.
+You can do so by either setting a `STOCKPILE_CONFIGURATION_FILE` environment
+variable or by executing a configuration block during runtime (for Rails create
+`config/initializers/stockpile.rb` with following content):
+
+```
+Stockpile.configure do |configuration|
+  configuration.configuration_file = <PATH/TO/FILE>
+end
+```
+
+Second thing to do is to create a `.yml` configuration file. It has to have at
+least two database definitions for mirroring. Providing `sentinels` is
+optional. Everything else is mandatory:
+
+
+```
+---
+commander:
+  url: 'redis://redis-2-host:6379/0'
+  sentinels: '8.8.8.8:42,8.8.4.4:42'
+  pool_options:
+    size: 5
+    timeout: 5
+commander_2x:
+  url: 'redis://redis-3-host:6379/0'
+  sentinels: '9.9.9.9:42,9.9.4.4:42'
+  pool_options:
+    size: 5
+    timeout: 5
+```
+
+From that point everything that would be written to `commander` is now also
+being written to `commander_2x`.
+
+
 ### Compression of Cached Content
 Stockpile optionally supports compression of cached content; you will not see
 much benefit from compressing small strings but once you start caching bigger

--- a/lib/stockpile.rb
+++ b/lib/stockpile.rb
@@ -142,7 +142,7 @@ module Stockpile
         yield connection
       end
     end
-    
+
     redis_connections.with(db: db) do |connection|
       yield connection
     end

--- a/lib/stockpile.rb
+++ b/lib/stockpile.rb
@@ -124,13 +124,25 @@ module Stockpile
 
   # API to communicate with Redis database backing cache up.
   #
+  # @param db [Symbol] (optional) Which Redis database to execute on.
+  #   Defaults to `:default`
+  # @param mirrorable [true, false] (optional) Check for a second Redis
+  #   database to execute on by appending `_2x` to the db option.
+  #   Defaults to `false`
+  #
   # @yield [redis]
   #
   # @example Store a value in Redis at given key
   #   Store.redis { |r| r.set('meaning_of_life', 42) }
   #
   # @return Returns a result of interaction with Redis
-  def redis(db: :default)
+  def redis(db: :default, mirrorable: false)
+    if mirrorable && redis_connections.include?(db: "#{db}_2x")
+      redis_connections.with(db: "#{db}_2x") do |connection|
+        yield connection
+      end
+    end
+    
     redis_connections.with(db: db) do |connection|
       yield connection
     end

--- a/lib/stockpile/cache.rb
+++ b/lib/stockpile/cache.rb
@@ -47,7 +47,7 @@ module Stockpile
                   Oj.dump(payload)
                 end
 
-      Stockpile.redis(db: db) { |r| r.setex(key, ttl, payload) }
+      Stockpile.redis(db: db, mirrorable: true) { |r| r.setex(key, ttl, payload) }
     end
   end
 end

--- a/lib/stockpile/cached_value_expirer.rb
+++ b/lib/stockpile/cached_value_expirer.rb
@@ -22,7 +22,7 @@ module Stockpile
     module_function
 
     def expire_cached(db: :default, key:)
-      Stockpile.redis(db: db) { |r| r.expire(key, 0) }
+      Stockpile.redis(db: db, mirrorable: true) { |r| r.expire(key, 0) }
     end
   end
 end

--- a/lib/stockpile/lock.rb
+++ b/lib/stockpile/lock.rb
@@ -53,7 +53,9 @@ module Stockpile
     end
 
     def lock
-      Stockpile.redis(db: db, mirrorable: true) { |r| r.set(lock_key, 1, nx: true, ex: Stockpile.configuration.lock_expiration) }
+      Stockpile.redis(db: db, mirrorable: true) do |redis|
+        redis.set(lock_key, 1, nx: true, ex: Stockpile.configuration.lock_expiration)
+      end
     end
 
     def successful_execution

--- a/lib/stockpile/lock.rb
+++ b/lib/stockpile/lock.rb
@@ -53,7 +53,7 @@ module Stockpile
     end
 
     def lock
-      Stockpile.redis(db: db) { |r| r.set(lock_key, 1, nx: true, ex: Stockpile.configuration.lock_expiration) }
+      Stockpile.redis(db: db, mirrorable: true) { |r| r.set(lock_key, 1, nx: true, ex: Stockpile.configuration.lock_expiration) }
     end
 
     def successful_execution

--- a/lib/stockpile/locked_execution_result.rb
+++ b/lib/stockpile/locked_execution_result.rb
@@ -28,7 +28,7 @@ module Stockpile
     end
 
     def release_lock
-      Stockpile.redis(db: db) { |r| r.expire(lock_key, 0) }
+      Stockpile.redis(db: db, mirrorable: true) { |r| r.expire(lock_key, 0) }
     end
 
     def success?

--- a/lib/stockpile/redis_connections.rb
+++ b/lib/stockpile/redis_connections.rb
@@ -26,6 +26,10 @@ module Stockpile
       instance_variable_get("@#{db}_compression".to_sym)
     end
 
+    def include?(db:)
+      instance_variable_defined?("@#{db}".to_sym)
+    end
+
     def with(db:)
       instance_variable_get("@#{db}".to_sym).with do |connection|
         yield connection

--- a/spec/stockpile/redis_connections_spec.rb
+++ b/spec/stockpile/redis_connections_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe Stockpile::RedisConnections do
     end
   end
 
+  describe '#include?' do
+    it 'returns true if the instance variable has been set' do
+      Stockpile::RedisConnections.instance_variable_set(:@foo, Object.new)
+
+      expect(Stockpile::RedisConnections.include?(db: 'foo')).to eq(true)
+    end
+
+    it 'returns false if the instance variable has not been set' do
+      expect(Stockpile::RedisConnections.include?(db: 'bar')).to eq(false)
+    end
+  end
+
   describe '#with' do
     class Klazz
       def self.with

--- a/spec/stockpile_spec.rb
+++ b/spec/stockpile_spec.rb
@@ -60,9 +60,9 @@ RSpec.describe Stockpile do
       expect { |b| Stockpile.redis(&b) }.to yield_control
     end
 
-    it 'yields control twice for mirrorable commands when a _2x db exists' do      
+    it 'yields control twice for mirrorable commands when a _2x db exists' do
       Stockpile::RedisConnections.instance_variable_set(:@default_2x, ConnectionPool.new { Object.new })
-      
+
       expect { |b| Stockpile.redis(mirrorable: true, &b) }.to yield_control.twice
 
       Stockpile::RedisConnections.remove_instance_variable(:@default_2x)
@@ -71,10 +71,10 @@ RSpec.describe Stockpile do
     it 'yields control once for mirrorable commands when a _2x db does not exist' do
       expect { |b| Stockpile.redis(mirrorable: true, &b) }.to yield_control.once
     end
-    
-    it 'yields control once for non-mirrorable commands when a _2x db exists' do      
+
+    it 'yields control once for non-mirrorable commands when a _2x db exists' do
       Stockpile::RedisConnections.instance_variable_set(:@default_2x, ConnectionPool.new { Object.new })
-      
+
       expect { |b| Stockpile.redis(&b) }.to yield_control.once
 
       Stockpile::RedisConnections.remove_instance_variable(:@default_2x)

--- a/spec/stockpile_spec.rb
+++ b/spec/stockpile_spec.rb
@@ -59,6 +59,26 @@ RSpec.describe Stockpile do
     it 'yields control' do
       expect { |b| Stockpile.redis(&b) }.to yield_control
     end
+
+    it 'yields control twice for mirrorable commands when a _2x db exists' do      
+      Stockpile::RedisConnections.instance_variable_set(:@default_2x, ConnectionPool.new { Object.new })
+      
+      expect { |b| Stockpile.redis(mirrorable: true, &b) }.to yield_control.twice
+
+      Stockpile::RedisConnections.remove_instance_variable(:@default_2x)
+    end
+
+    it 'yields control once for mirrorable commands when a _2x db does not exist' do
+      expect { |b| Stockpile.redis(mirrorable: true, &b) }.to yield_control.once
+    end
+    
+    it 'yields control once for non-mirrorable commands when a _2x db exists' do      
+      Stockpile::RedisConnections.instance_variable_set(:@default_2x, ConnectionPool.new { Object.new })
+      
+      expect { |b| Stockpile.redis(&b) }.to yield_control.once
+
+      Stockpile::RedisConnections.remove_instance_variable(:@default_2x)
+    end
   end
 
   describe '#redis_connection_pool' do


### PR DESCRIPTION
- Adds a `mirrorable` option to `Stockpile.redis` so that in addition to yielding the db for the key you passed (`default`) it will also yield for a matching key if it exists (`default_2x`). This allows you to execute a single Redis command inside of Stockpile against two databases.
- Updates Stockpile so that locks, cache writes, and lock expirations use this new `mirrorable` option, leaving the read methods alone so they continue to call execute once

The idea would be we could deploy this per Stockpile database, wait for the longest TTL on that database, then deploy once more  promoting the `default_2x` database key to be the `default` database key so reads now take place on the new cluster.